### PR TITLE
Fix restack using commit hash instead of deleted branch (+1 more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ rungs config get userPrefix          # Get a setting
 
 - 🎯 **Focused Reviews** - Each PR contains logically related changes
 - 🚀 **Parallel Development** - Work on new features while others are in review
-- 🔧 **Easy Maintenance** - Automatic stack cleanup when PRs are merged
+- 🔧 **Easy Maintenance** - Automatic stack cleanup and rebase when PRs are merged
 - 📈 **Better Velocity** - Merge parts of features as they're ready
 - 🔄 **Always Current** - Auto-syncs with GitHub on every command
 

--- a/bin/rungs
+++ b/bin/rungs
@@ -117,6 +117,14 @@ class GitManager {
       throw new Error(`Failed to get remote URL: ${error}`);
     }
   }
+  async getCommitHash(ref) {
+    try {
+      const result = await Bun.$`git rev-parse ${ref}`.text();
+      return result.trim();
+    } catch (error) {
+      throw new Error(`Failed to get commit hash for ${ref}: ${error}`);
+    }
+  }
   async getCommitMessage(hash) {
     try {
       const result = await Bun.$`git log -1 --pretty=format:"%s" ${hash}`.text();
@@ -1108,16 +1116,23 @@ ${newCommits.map((c) => `  - ${c.hash.slice(0, 7)}: ${c.message}`).join(`
         endGroup();
       }
     }
+    let oldBaseCommit;
+    if (prBeingMerged && deleteBranch && mergeMethod === "squash") {
+      const dependentPRs = currentStack.prs.filter((pr) => pr.base === prBeingMerged.head && pr.number !== prNumber);
+      if (dependentPRs.length > 0) {
+        oldBaseCommit = await this.git.getCommitHash(`origin/${prBeingMerged.head}`);
+      }
+    }
     logInfo(`Merging PR #${prNumber} using ${mergeMethod} merge...`);
     await this.github.mergePullRequest(prNumber, mergeMethod, deleteBranch);
     logSuccess(`\u2705 Successfully merged PR #${prNumber}`);
-    if (prBeingMerged && deleteBranch && mergeMethod === "squash") {
+    if (prBeingMerged && deleteBranch && mergeMethod === "squash" && oldBaseCommit) {
       const dependentPRs = currentStack.prs.filter((pr) => pr.base === prBeingMerged.head && pr.number !== prNumber);
       if (dependentPRs.length > 0) {
         const config = await this.config.getAll();
         const prBeingMergedIndex = currentStack.prs.findIndex((pr) => pr.number === prNumber);
         const newBase = prBeingMergedIndex > 0 ? currentStack.prs[prBeingMergedIndex - 1].head : config.defaultBranch;
-        await this.restackDependents(dependentPRs, prBeingMerged.head, newBase);
+        await this.restackDependents(dependentPRs, oldBaseCommit, newBase);
       }
     }
     logInfo("\uD83D\uDD04 Updating local main with latest changes...");
@@ -1135,7 +1150,7 @@ ${newCommits.map((c) => `  - ${c.hash.slice(0, 7)}: ${c.message}`).join(`
     await this.getCurrentStack();
     logInfo("Stack state updated successfully!");
   }
-  async restackDependents(dependentPRs, oldBase, newBase) {
+  async restackDependents(dependentPRs, oldBaseCommit, newBase) {
     if (dependentPRs.length === 0) {
       return;
     }
@@ -1148,8 +1163,7 @@ ${newCommits.map((c) => `  - ${c.hash.slice(0, 7)}: ${c.message}`).join(`
         try {
           await this.git.checkoutBranch(pr.head);
           await this.git.fetchBranch(newBase);
-          await this.git.fetchBranch(oldBase);
-          await this.git.rebaseOntoTarget(`origin/${newBase}`, `origin/${oldBase}`);
+          await this.git.rebaseOntoTarget(`origin/${newBase}`, oldBaseCommit);
           await this.git.pushForceWithLease(pr.head);
           logSuccess(`Restacked PR #${pr.number}`, 1);
         } catch (error) {

--- a/src/git-manager.ts
+++ b/src/git-manager.ts
@@ -158,6 +158,15 @@ export class GitManager {
     }
   }
 
+  async getCommitHash(ref: string): Promise<string> {
+    try {
+      const result = await Bun.$`git rev-parse ${ref}`.text();
+      return result.trim();
+    } catch (error) {
+      throw new Error(`Failed to get commit hash for ${ref}: ${error}`);
+    }
+  }
+
   async getCommitMessage(hash: string): Promise<string> {
     try {
       const result = await Bun.$`git log -1 --pretty=format:"%s" ${hash}`.text();

--- a/tests/squash-merge-commit-hash.test.ts
+++ b/tests/squash-merge-commit-hash.test.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "bun:test";
+import { GitManager } from "../src/git-manager";
+
+class MockGitManager extends GitManager {
+  private commitHashes: Map<string, string> = new Map();
+  private fetchedBranches: Set<string> = new Set();
+  private rebaseCommands: string[] = [];
+
+  // Mock the getCommitHash method
+  async getCommitHash(ref: string): Promise<string> {
+    const hash = this.commitHashes.get(ref);
+    if (!hash) {
+      throw new Error(`Failed to get commit hash for ${ref}`);
+    }
+    return hash;
+  }
+
+  // Mock fetchBranch to track what was fetched
+  async fetchBranch(branch: string): Promise<void> {
+    if (branch === "deleted-branch") {
+      throw new Error(`Failed to fetch branch ${branch}: does not exist`);
+    }
+    this.fetchedBranches.add(branch);
+  }
+
+  // Mock rebaseOntoTarget to track rebase commands
+  async rebaseOntoTarget(newBase: string, oldBase: string): Promise<void> {
+    this.rebaseCommands.push(`rebase --onto ${newBase} ${oldBase}`);
+  }
+
+  // Mock pushForceWithLease
+  async pushForceWithLease(branch: string): Promise<void> {
+    // No-op for testing
+  }
+
+  // Mock checkoutBranch  
+  async checkoutBranch(branch: string): Promise<void> {
+    // No-op for testing
+  }
+
+  // Mock getCurrentBranch
+  async getCurrentBranch(): Promise<string> {
+    return "main";
+  }
+
+  // Test helper methods
+  setCommitHash(ref: string, hash: string) {
+    this.commitHashes.set(ref, hash);
+  }
+
+  getFetchedBranches(): Set<string> {
+    return this.fetchedBranches;
+  }
+
+  getRebaseCommands(): string[] {
+    return this.rebaseCommands;
+  }
+}
+
+test("squash merge restack should use commit hash instead of deleted branch", async () => {
+  const mockGit = new MockGitManager();
+  
+  // Setup: parent branch commit hash before deletion
+  const parentCommitHash = "abc123def456";
+  mockGit.setCommitHash("origin/feature-parent", parentCommitHash);
+  
+  // Simulate the scenario:
+  // 1. feature-parent branch exists before merge
+  // 2. We capture its commit hash
+  const capturedHash = await mockGit.getCommitHash("origin/feature-parent");
+  expect(capturedHash).toBe(parentCommitHash);
+  
+  // 3. Branch gets deleted during squash merge (GitHub does this automatically)
+  // 4. We try to restack dependent branch using the captured commit hash
+  
+  // This should work - using commit hash instead of branch name
+  await mockGit.rebaseOntoTarget("origin/main", capturedHash);
+  
+  // This should fail - trying to fetch deleted branch
+  try {
+    await mockGit.fetchBranch("deleted-branch");
+    expect(true).toBe(false); // Should not reach here
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("does not exist");
+  }
+  
+  // Verify the rebase used the commit hash directly
+  const rebaseCommands = mockGit.getRebaseCommands();
+  expect(rebaseCommands).toContain(`rebase --onto origin/main ${parentCommitHash}`);
+  
+  // Verify we didn't try to fetch the commit hash as a branch
+  const fetchedBranches = mockGit.getFetchedBranches();
+  expect(fetchedBranches.has(parentCommitHash)).toBe(false);
+});
+
+test("getCommitHash method should retrieve commit SHA for any git reference", async () => {
+  const mockGit = new MockGitManager();
+  
+  // Test various reference types
+  const testCases = [
+    { ref: "origin/main", hash: "main123abc" },
+    { ref: "origin/feature-branch", hash: "feature456def" },
+    { ref: "HEAD", hash: "head789ghi" },
+    { ref: "v1.0.0", hash: "tag012jkl" }
+  ];
+  
+  for (const testCase of testCases) {
+    mockGit.setCommitHash(testCase.ref, testCase.hash);
+    const result = await mockGit.getCommitHash(testCase.ref);
+    expect(result).toBe(testCase.hash);
+  }
+});
+
+test("getCommitHash should handle non-existent references", async () => {
+  const mockGit = new MockGitManager();
+  
+  try {
+    await mockGit.getCommitHash("origin/non-existent-branch");
+    expect(true).toBe(false); // Should not reach here
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Failed to get commit hash");
+  }
+});


### PR DESCRIPTION
Stack of 2 commits:

- Fix restack using commit hash instead of deleted branch
- Update README to mention automatic rebase functionality