### PR TITLE
Mark rungs stack verbose output issue as completed in ISSUES.md (+1 more)

### DIFF
--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -11,7 +11,7 @@ This document tracks all work items needed to implement the rungs CLI project.
   - [x] Separately from the stack, show any local commits that don't below to a stack. 'Unstacked'
   - [x] Overall commit count is not useful (and wrong at the moment) - removed totalCommits field
 
-- `rungs stack` output is verbose. Not sure if this is beacuse verbose mode is the default or not. There is a related feature for this.
+- [x] `rungs stack` output is verbose. Not sure if this is beacuse verbose mode is the default or not. There is a related feature for this.
 
 
 - This strange output from rungs status

--- a/tests/output-mode-formatting.test.ts
+++ b/tests/output-mode-formatting.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeEach, mock } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
 import { OperationTracker } from "../src/operation-tracker.js";
 import { output, setOutputMode } from "../src/output-manager.js";
 


### PR DESCRIPTION
Stack of 2 commits:

- Mark rungs stack verbose output issue as completed in ISSUES.md
- Fix test import - add missing afterEach to output-mode-formatting.test.ts